### PR TITLE
Add Python vs Rust HTTP benchmark

### DIFF
--- a/benchmarks/benchmark.md
+++ b/benchmarks/benchmark.md
@@ -1,0 +1,10 @@
+# HTTP Benchmark
+
+Benchmark comparing Python httpx client with a Rust reqwest client against a simple Go server.
+
+- **Requests**: 1000 sequential GET requests to `http://localhost:8000/`
+- **Python (httpx)**: 0.9377s
+- **Rust (reqwest)**: 0.1834s
+- **Speedup**: 5.11x faster
+
+Generated on: Mon Aug 11 12:35:26 UTC 2025

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,0 +1,70 @@
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+
+SERVER_CMD = ["go", "run", "benchmarks/server.go"]
+RUST_CLIENT_MANIFEST = Path("benchmarks/rust-client/Cargo.toml")
+RUST_BINARY = Path("benchmarks/rust-client/target/release/rust-client")
+URL = "http://localhost:8000/"
+
+
+def start_server():
+    return subprocess.Popen(
+        SERVER_CMD,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def wait_for_server(timeout: float = 5.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            httpx.get(URL)
+            return
+        except httpx.HTTPError:
+            time.sleep(0.1)
+    raise RuntimeError("Server did not start in time")
+
+
+def benchmark_python(requests: int) -> float:
+    with httpx.Client() as client:
+        start = time.perf_counter()
+        for _ in range(requests):
+            r = client.get(URL)
+            r.raise_for_status()
+        end = time.perf_counter()
+    return end - start
+
+
+def benchmark_rust(requests: int) -> float:
+    if not RUST_BINARY.exists():
+        subprocess.check_call(
+            ["cargo", "build", "--release", "--manifest-path", str(RUST_CLIENT_MANIFEST)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    result = subprocess.check_output([str(RUST_BINARY), str(requests)])
+    return float(result.strip())
+
+
+def main():
+    requests = 1000
+    server = start_server()
+    try:
+        wait_for_server()
+        py_time = benchmark_python(requests)
+        rust_time = benchmark_rust(requests)
+        speedup = py_time / rust_time
+        print(f"Python transport: {py_time:.4f}s")
+        print(f"Rust transport: {rust_time:.4f}s")
+        print(f"Speedup: {speedup:.2f}x")
+    finally:
+        server.terminate()
+        server.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/rust-client/Cargo.toml
+++ b/benchmarks/rust-client/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/benchmarks/rust-client/src/main.rs
+++ b/benchmarks/rust-client/src/main.rs
@@ -1,0 +1,16 @@
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let iterations: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1000);
+    let client = reqwest::Client::new();
+    let url = "http://localhost:8000/";
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let resp = client.get(url).send().await.unwrap();
+        resp.bytes().await.unwrap();
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    println!("{elapsed}");
+}

--- a/benchmarks/server.go
+++ b/benchmarks/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte("Hello, World!"))
+}
+
+func main() {
+    http.HandleFunc("/", handler)
+    fmt.Println("Go server listening on :8000")
+    if err := http.ListenAndServe(":8000", nil); err != nil {
+        panic(err)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Go HTTP server for benchmarking
- add Python and Rust clients to measure request performance
- document benchmark results in benchmarks/benchmark.md

## Testing
- `pytest tests` *(fails: async functions not awaited, TypeError in rust transport)*
- `python benchmarks/benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_6899e105ba988320a1b4d2193053cc7d